### PR TITLE
Ensure that the package manager installed

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ structstruck::strike! {
                 RemoveFailed(Vec<String>),
                 SearchFailed(String),
                 UpdateFailed(Option<Vec<String>>),
+                PackageManagerNotInstalled,
             },
             PackageManager
         ),
@@ -30,7 +31,7 @@ pub fn unwrap_depot_error<T>(result: DepotResult<T>) -> T {
                     DepotError::UnknownOperatingSystem =>
                         "Unable to determine your current operating system.".to_string(),
                     DepotError::UnknownPackageManager =>
-                        "The package manager is unknown or not supported.".to_string(),
+                        "The package manager is unknown or not supported by your version of depot.".to_string(),
                     DepotError::PackageManagerError(pme, pm) => match pme {
                         PackageManagerError::InstallFailed(package) => format!(
                             "Failed to install package: {} using {:?}",
@@ -52,6 +53,8 @@ pub fn unwrap_depot_error<T>(result: DepotResult<T>) -> T {
                             ),
                             None => "Failed to update all packages.".to_string(),
                         },
+                        PackageManagerError::PackageManagerNotInstalled =>
+                            format!("{:?} is not installed on your system.", pm),
                     },
                 }
             );

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,8 @@ pub fn unwrap_depot_error<T>(result: DepotResult<T>) -> T {
                     DepotError::UnknownOperatingSystem =>
                         "Unable to determine your current operating system.".to_string(),
                     DepotError::UnknownPackageManager =>
-                        "The package manager is unknown or not supported by your version of depot.".to_string(),
+                        "The package manager is unknown or not supported by your version of depot."
+                            .to_string(),
                     DepotError::PackageManagerError(pme, pm) => match pme {
                         PackageManagerError::InstallFailed(package) => format!(
                             "Failed to install package: {} using {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 ///  - get the os name and deduce it from there
 fn run() -> DepotResult<()> {
     let args = Args::parse();
-    let package_manager = get_package_manager(args.package_manager)?;
+    let package_manager = get_package_manager(args.package_manager)?.ensure_pm_installed()?;
     match args.cmd {
         Command::Install(i) => package_manager.install(&i)?,
         Command::Remove(r) => package_manager.remove(&r)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,15 @@
 use clap::Parser;
 use depot::{
     cli::{Args, Command},
-    error::unwrap_depot_error,
+    error::{unwrap_depot_error, DepotResult},
     package_manager::get_package_manager,
 };
+
+/// Entry point of the program
+/// Handle the error returned by the program
+fn main() {
+    unwrap_depot_error(run());
+}
 
 /// Main function of the program
 /// Parse the command line arguments
@@ -11,13 +17,14 @@ use depot::{
 ///  - the command line arguments
 ///  - the environment variables
 ///  - get the os name and deduce it from there
-fn main() {
+fn run() -> DepotResult<()> {
     let args = Args::parse();
-    let package_manager = unwrap_depot_error(get_package_manager(args.package_manager));
+    let package_manager = get_package_manager(args.package_manager)?;
     match args.cmd {
-        Command::Install(i) => unwrap_depot_error(package_manager.install(&i)),
-        Command::Remove(r) => unwrap_depot_error(package_manager.remove(&r)),
-        Command::Search(s) => unwrap_depot_error(package_manager.search(&s)),
-        Command::Update(u) => unwrap_depot_error(package_manager.update(&u)),
+        Command::Install(i) => package_manager.install(&i)?,
+        Command::Remove(r) => package_manager.remove(&r)?,
+        Command::Search(s) => package_manager.search(&s)?,
+        Command::Update(u) => package_manager.update(&u)?,
     };
+    Ok(())
 }

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -221,7 +221,9 @@ impl PackageManager {
     /// PackageManager::Dnf.ensure_pm_installed().unwrap();
     /// ```
     pub fn ensure_pm_installed(&self) -> DepotResult<Self> {
-        let temp = Command::new("which").arg(format!("{:?}", self).to_lowercase()).output();
+        let temp = Command::new("which")
+            .arg(format!("{:?}", self).to_lowercase())
+            .output();
         if temp.is_ok() && temp.unwrap().status.success() {
             Ok(self.clone())
         } else {

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -214,7 +214,7 @@ impl PackageManager {
     /// If it is not installed, return an error.
     /// ```
     /// use depot::package_manager::PackageManager;
-    /// assert!(PackageManager::Pacman.ensure_pm_installed().is_ok());
+    /// assert!(PackageManager::Apt.ensure_pm_installed().is_ok());
     /// ```
     /// ```should_panic
     /// use depot::package_manager::PackageManager;

--- a/src/package_manager.rs
+++ b/src/package_manager.rs
@@ -209,6 +209,28 @@ impl PackageManager {
             ))
         }
     }
+
+    /// Test if the package manager is installed.
+    /// If it is not installed, return an error.
+    /// ```
+    /// use depot::package_manager::PackageManager;
+    /// assert!(PackageManager::Pacman.ensure_pm_installed().is_ok());
+    /// ```
+    /// ```should_panic
+    /// use depot::package_manager::PackageManager;
+    /// PackageManager::Dnf.ensure_pm_installed().unwrap();
+    /// ```
+    pub fn ensure_pm_installed(&self) -> DepotResult<Self> {
+        let temp = Command::new("which").arg(format!("{:?}", self).to_lowercase()).output();
+        if temp.is_ok() && temp.unwrap().status.success() {
+            Ok(self.clone())
+        } else {
+            Err(DepotError::PackageManagerError(
+                error::PackageManagerNotInstalled,
+                self.clone(),
+            ))
+        }
+    }
 }
 
 /// Get the package manager to use.


### PR DESCRIPTION
The program nows errors at the beginning of the program if the selected package manager is not avalible on the computer, the error message is now "... is not installed on your system"

Before if you tried to use depot with a package manager you don't have on your computer, the program errored depot was calling the package manager and the error message was "Unable to install ... using ..."